### PR TITLE
Make (un)lockroom not simply repeat that they did the action

### DIFF
--- a/Lock Room/server/src/commands/mod/lockroom.js
+++ b/Lock Room/server/src/commands/mod/lockroom.js
@@ -20,6 +20,13 @@ exports.run = async (core, server, socket, data) => {
     return server._police.frisk(socket.remoteAddress, 10);
   }
 
+  if (core.locked[socket.channel]) {
+    server.reply({
+      cmd: 'info',
+      text: "Channel is already locked."
+    }, socket);
+    return;
+  }
   // apply lock flag to channel list
   core.locked[socket.channel] = true;
 

--- a/Lock Room/server/src/commands/mod/unlockroom.js
+++ b/Lock Room/server/src/commands/mod/unlockroom.js
@@ -13,6 +13,14 @@ exports.run = async (core, server, socket, data) => {
     core.locked = [];
   }
 
+  if (!core.locked[socket.channel]) {
+    server.reply({
+      cmd: 'info',
+      text: 'Channel is already unlocked.'
+    }, socket);
+    return;
+  }
+
   core.locked[socket.channel] = false;
 
   server.broadcast({


### PR DESCRIPTION
This makes so when using lockroom it won't simply say "Locked Room: ?channel" whenever you use it, but it will tell you if it's already locked. This is a minor improvement to current behavior, and lets the moderators know if the room was *actually* locked.  
(Note: this module, before and after this PR, has the same issue as a lot of others. There is text send solely to mods, but which doesn't get sent to the Admin when it's done.)